### PR TITLE
Generate assertions using opt.forall() instead of opt.get

### DIFF
--- a/src/validations.ts
+++ b/src/validations.ts
@@ -1,10 +1,76 @@
+const arrayLikeValidationOps: any = {
+  minItems: {
+    lhs: (paramName: string, value: any) => value === 1 ? `${paramName}.nonEmpty` : `${paramName}.length`,
+    comparator: (paramName: string, value: any) => value === 1 ? null : '>=',
+    rhs: (paramName: string, value: any) => value === 1 ? null : value,
+    msg: (paramName: string, value: any) => `\`${paramName}\` must have minimum ${value} item(s)`
+  },
+  maxItems: {
+    lhs: (paramName: string, value: any) => value === 0 ? `${paramName}.isEmpty` : `${paramName}.length`,
+    comparator: (paramName: string, value: any) => value === 0 ? null : '<=',
+    rhs: (paramName: string, value: any) => value === 0 ? null : value,
+    msg: (paramName: string, value: any) => `\`${paramName}\` must have maximum ${value} item(s)`
+  },
+  uniqueItems: {
+    lhs: (paramName: string, value: any) => `${paramName}.length`,
+    comparator: (paramName: string, value: any) => '>',
+    rhs: (paramName: string, value: any) => `${paramName}.distinct.length`,
+    msg: (paramName: string, value: any) => `\`${paramName}\` contains duplicate items`
+  }
+}
 
-const arrayLikeValidations = {
-  // maxContains - NOT SUPPORTED
-  // minContains - NOT SUPPORTED
-  minItems: (paramName: string, value: string) => `assert( ${paramName}.length >= ${value},  "\`${paramName}\` must have minimum ${value} items" )`,
-  maxItems: (paramName: string, value: string) => `assert( ${paramName}.length <= ${value},  "\`${paramName}\` must have maximum ${value} items" )`,
-  uniqueItems: (paramName: string, value: boolean) => value ? `assert( ${paramName}.length == ${paramName}.distinct.length,  "\`${paramName}\` contains duplicate items" )` : ''
+const numberLikeValidationOps: any = {
+  multipleOf: {
+    lhs: (paramName: string, value: any) => paramName,
+    comparator: (paramName: string, value: any) => '%',
+    rhs: (paramName: string, value: any) => `${value} === 0`,
+    msg: (paramName: string, value: any) => `\`${paramName}\` must be multiple of (divisible by) ${value}`
+  },
+  maximum: {
+    lhs: (paramName: string, value: any) => paramName,
+    comparator: (paramName: string, value: any) => '<=',
+    rhs: (paramName: string, value: any) => value,
+    msg: (paramName: string, value: any) => `\`${paramName}\` must be less than or equal to ${value}`
+  },
+  exclusiveMaximum: {
+    lhs: (paramName: string, value: any) => paramName,
+    comparator: (paramName: string, value: any) => '<',
+    rhs: (paramName: string, value: any) => value,
+    msg: (paramName: string, value: any) => `\`${paramName}\` must be less than ${value}`
+  },
+  minimum: {
+    lhs: (paramName: string, value: any) => paramName,
+    comparator: (paramName: string, value: any) => '>=',
+    rhs: (paramName: string, value: any) => value,
+    msg: (paramName: string, value: any) => `\`${paramName}\` must be greater than or equal to ${value}`
+  },
+  exclusiveMinimum: {
+    lhs: (paramName: string, value: any) => paramName,
+    comparator: (paramName: string, value: any) => '>',
+    rhs: (paramName: string, value: any) => value,
+    msg: (paramName: string, value: any) => `\`${paramName}\` must be greater than ${value}`
+  }
+}
+
+const stringLikeValidationOps: any = {
+  maxLength: {
+    lhs: (paramName: string, value: any) => `${paramName}.length`,
+    comparator: (paramName: string, value: any) => '<=',
+    rhs: (paramName: string, value: any) => value,
+    msg: (paramName: string, value: any) => `\`${paramName}\` does not meet maximum length of ${value}`
+  },
+  minLength: {
+    lhs: (paramName: string, value: any) => value === 1 ? `${paramName}.nonEmpty` : `${paramName}.length`,
+    comparator: (paramName: string, value: any) => value === 1 ? null : '>=',
+    rhs: (paramName: string, value: any) => value === 1 ? null : value,
+    msg: (paramName: string, value: any) => `\`${paramName}\` does not meet minimum length of ${value}`
+  },
+  pattern: {
+    lhs: (paramName: string, value: any) => `${paramName}.matches("${value}")`,
+    comparator: (paramName: string, value: any) => null,
+    rhs: (paramName: string, value: any) => null,
+    msg: (paramName: string, value: any) => `\`${paramName}\` does not match the pattern`
+  }
 };
 
 const objectLikeValidations = {
@@ -13,23 +79,34 @@ const objectLikeValidations = {
   // required - Case class parameters are wrapped in `Option[]` if they are NOT required.
 };
 
-const numberLikeValidations = {
-  multipleOf: (paramName: string, value: number) => `assert( ${paramName} % ${value} == 0, "\`${paramName}\` must be multiple of (divisible by) ${value}" )`,
-  maximum: (paramName: string, value: number) => `assert( ${paramName} <= ${value}, "\`${paramName}\` must be less than or equal to ${value}" )`,
-  exclusiveMaximum: (paramName: string, value: number) => `assert( ${paramName} < ${value}, "\`${paramName}\` must be less than ${value}" )`,
-  minimum: (paramName: string, value: number) => `assert( ${paramName} >= ${value}, "\`${paramName}\` must be greater than or equal to ${value}" )`,
-  exclusiveMinimum: (paramName: string, value: number) => `assert( ${paramName} > ${value}, "\`${paramName}\` must be greater than ${value}" )`
-};
-
-const stringLikeValidations = {
-  maxLength: (paramName: string, value: number) => `assert( ${paramName}.length <= ${value}, "\`${paramName}\` does not meet maximum length of ${value}" )`,
-  minLength: (paramName: string, value: number) => `assert( ${paramName}.length >= ${value}, "\`${paramName}\` does not meet minimum length of ${value}" )`,
-  pattern: (paramName: string, value: string) => `assert( ${paramName}.matches("${value}"), "\`${paramName}\` does not match the pattern" )`
-};
-
 export const validations: any = {
-  ...arrayLikeValidations,
-  ...objectLikeValidations,
-  ...numberLikeValidations,
-  ...stringLikeValidations
-};
+  ...arrayLikeValidationOps,
+  ...numberLikeValidationOps,
+  ...stringLikeValidationOps,
+  ...objectLikeValidations
+}
+
+const formatEquation = (lhs: string, comparator: string, rhs: string): string => {
+  let equation = lhs;
+  if (comparator !== null) equation += ` ${comparator}`;
+  if (rhs !== null) equation += ` ${rhs}`;
+  return equation;
+}
+
+const generateAssertionFromOp = (lhs: string, comparator: string, rhs: string, msg: string) => {
+  return `assert( ${formatEquation(lhs, comparator, rhs)}, "${msg}" )`
+}
+
+const generateOptionalAssertionFromOp = (paramName: string, lhs: string, comparator: string, rhs: string, msg: string) => {
+  return `assert( ${paramName}.forall(${formatEquation(lhs, comparator, rhs)}), "${msg}" )`
+}
+
+export const generateAssertion = (opName: string, paramName: string, value: any, isOptional: boolean): string | null => {
+  if (!(opName in validations)) return null;
+  const op: any = validations[opName];
+  if (isOptional) {
+    return generateOptionalAssertionFromOp(paramName, op.lhs('_', value), op.comparator('_', value), op.rhs('_', value), op.msg(paramName, value))
+  } else {
+    return generateAssertionFromOp(op.lhs(paramName, value), op.comparator(paramName, value), op.rhs(paramName, value), op.msg(paramName, value))
+  }
+}

--- a/tests/converter.test.ts
+++ b/tests/converter.test.ts
@@ -98,7 +98,8 @@ describe('Function convert()', () => {
 
     const result = await convert(latLongSchema, config);
     expect(result).to.be.an('string');
-    expect(result).to.contain('assert');
+    expect(result).to.contain('assert( latitude >= -90, "`latitude` must be greater than or equal to -90" )')
+    expect(result).to.contain('assert( longitude <= 180, "`longitude` must be less than or equal to 180" )')
 
     const occurrences = (result.match(/assert\(/g) || []).length;
     expect(occurrences).to.eql(4);
@@ -214,9 +215,9 @@ describe('Function convert()', () => {
 
     const result = await convert(allOfSchema, config);
     expect(result).to.be.an('string');
-    expect(result).to.contain('must be greater than or equal to 3');
-    expect(result).to.contain('must be multiple of (divisible by) 3');
-    expect(result).to.contain('must be multiple of (divisible by) 5');
+    expect(result).to.contain('assert( age.forall(_ >= 3), "`age` must be greater than or equal to 3" )');
+    expect(result).to.contain('assert( age.forall(_ % 3 === 0), "`age` must be multiple of (divisible by) 3" )');
+    expect(result).to.contain('assert( age.forall(_ % 5 === 0), "`age` must be multiple of (divisible by) 5" )');
 
   });
 
@@ -234,6 +235,7 @@ describe('Function convert()', () => {
     const config2 = { generateValidations: true };
     const result2 = await convert(allOfWithReferencesSchema, config2);
     expect(result2).to.contain('`type`: String');
+    expect(result2).to.contain('assert( state.length <= 2, "`state` does not meet maximum length of 2" )')
 
   });
 

--- a/tests/validations.test.ts
+++ b/tests/validations.test.ts
@@ -1,73 +1,73 @@
-// import { generateAssertion } from '../src/validations_v2';
-// import { assert } from 'chai';
+import { generateAssertion } from '../src/validations';
+import { assert } from 'chai';
 
-// describe('Validate array-like operations', () => {
-//   it('should validate array-like operations as expected', () => {
-//     const res1 = generateAssertion('minItems', 'tags', 0, true);
-//     assert(res1 === 'assert( tags.forall(_.length >= 0), "`tags` must have minimum 0 item(s)" )')
-//     const res11 = generateAssertion('minItems', 'tags', 2, false);
-//     assert(res11 === 'assert( tags.length >= 2, "`tags` must have minimum 2 item(s)" )')
-//     const res2 = generateAssertion('minItems', 'tags', 1, true);
-//     assert(res2 === 'assert( tags.forall(_.nonEmpty), "`tags` must have minimum 1 item(s)" )')
-//     const res21 = generateAssertion('minItems', 'tags', 4, false);
-//     assert(res21 === 'assert( tags.length >= 4, "`tags` must have minimum 4 item(s)" )')
+describe('Validate array-like operations', () => {
+  it('should validate array-like operations as expected', () => {
+    const res1 = generateAssertion('minItems', 'tags', 0, true);
+    assert(res1 === 'assert( tags.forall(_.length >= 0), "`tags` must have minimum 0 item(s)" )')
+    const res11 = generateAssertion('minItems', 'tags', 2, false);
+    assert(res11 === 'assert( tags.length >= 2, "`tags` must have minimum 2 item(s)" )')
+    const res2 = generateAssertion('minItems', 'tags', 1, true);
+    assert(res2 === 'assert( tags.forall(_.nonEmpty), "`tags` must have minimum 1 item(s)" )')
+    const res21 = generateAssertion('minItems', 'tags', 4, false);
+    assert(res21 === 'assert( tags.length >= 4, "`tags` must have minimum 4 item(s)" )')
 
-//     const res3 = generateAssertion('maxItems', 'tags', 0, true);
-//     assert(res3 === 'assert( tags.forall(_.isEmpty), "`tags` must have maximum 0 item(s)" )')
-//     const res31 = generateAssertion('maxItems', 'tags', 2, false);
-//     assert(res31 === 'assert( tags.length <= 2, "`tags` must have maximum 2 item(s)" )')
+    const res3 = generateAssertion('maxItems', 'tags', 0, true);
+    assert(res3 === 'assert( tags.forall(_.isEmpty), "`tags` must have maximum 0 item(s)" )')
+    const res31 = generateAssertion('maxItems', 'tags', 2, false);
+    assert(res31 === 'assert( tags.length <= 2, "`tags` must have maximum 2 item(s)" )')
 
-//     const res4 = generateAssertion('uniqueItems', 'tags', null, true);
-//     assert(res4 === 'assert( tags.forall(_.length > _.distinct.length), "`tags` contains duplicate items" )')
-//     const res41 = generateAssertion('uniqueItems', 'tags', null, false);
-//     assert(res41 === 'assert( tags.length > tags.distinct.length, "`tags` contains duplicate items" )')
+    const res4 = generateAssertion('uniqueItems', 'tags', null, true);
+    assert(res4 === 'assert( tags.forall(_.length > _.distinct.length), "`tags` contains duplicate items" )')
+    const res41 = generateAssertion('uniqueItems', 'tags', null, false);
+    assert(res41 === 'assert( tags.length > tags.distinct.length, "`tags` contains duplicate items" )')
 
-//     const res5 = generateAssertion('multipleOf', 'age', 3, true);
-//     assert(res5 === 'assert( age.forall(_ % 3 === 0), "`age` must be multiple of (divisible by) 3" )')
-//     const res51 = generateAssertion('multipleOf', 'age', 5, false);
-//     assert(res51 === 'assert( age % 5 === 0, "`age` must be multiple of (divisible by) 5" )')
-//   });
-// });
+    const res5 = generateAssertion('multipleOf', 'age', 3, true);
+    assert(res5 === 'assert( age.forall(_ % 3 === 0), "`age` must be multiple of (divisible by) 3" )')
+    const res51 = generateAssertion('multipleOf', 'age', 5, false);
+    assert(res51 === 'assert( age % 5 === 0, "`age` must be multiple of (divisible by) 5" )')
+  });
+});
 
-// describe('Validate number like operations', () => {
-//   it('should validate number-like operations as expected', () => {
-//     const res6 = generateAssertion('maximum', 'age', 18, true);
-//     assert(res6 === 'assert( age.forall(_ <= 18), "`age` must be less than or equal to 18" )')
-//     const res61 = generateAssertion('maximum', 'age', 18, false);
-//     assert(res61 === 'assert( age <= 18, "`age` must be less than or equal to 18" )')
-//     const res7 = generateAssertion('minimum', 'age', 18, true);
-//     assert(res7 === 'assert( age.forall(_ >= 18), "`age` must be greater than or equal to 18" )')
-//     const res71 = generateAssertion('minimum', 'age', 18, false);
-//     assert(res71 === 'assert( age >= 18, "`age` must be greater than or equal to 18" )')
+describe('Validate number like operations', () => {
+  it('should validate number-like operations as expected', () => {
+    const res6 = generateAssertion('maximum', 'age', 18, true);
+    assert(res6 === 'assert( age.forall(_ <= 18), "`age` must be less than or equal to 18" )')
+    const res61 = generateAssertion('maximum', 'age', 18, false);
+    assert(res61 === 'assert( age <= 18, "`age` must be less than or equal to 18" )')
+    const res7 = generateAssertion('minimum', 'age', 18, true);
+    assert(res7 === 'assert( age.forall(_ >= 18), "`age` must be greater than or equal to 18" )')
+    const res71 = generateAssertion('minimum', 'age', 18, false);
+    assert(res71 === 'assert( age >= 18, "`age` must be greater than or equal to 18" )')
 
-//     const res8 = generateAssertion('exclusiveMaximum', 'age', 18, true);
-//     assert(res8 === 'assert( age.forall(_ < 18), "`age` must be less than 18" )')
-//     const res81 = generateAssertion('exclusiveMaximum', 'age', 18, false);
-//     assert(res81 === 'assert( age < 18, "`age` must be less than 18" )')
+    const res8 = generateAssertion('exclusiveMaximum', 'age', 18, true);
+    assert(res8 === 'assert( age.forall(_ < 18), "`age` must be less than 18" )')
+    const res81 = generateAssertion('exclusiveMaximum', 'age', 18, false);
+    assert(res81 === 'assert( age < 18, "`age` must be less than 18" )')
 
-//     const res9 = generateAssertion('exclusiveMinimum', 'age', 18, true);
-//     assert(res9 === 'assert( age.forall(_ > 18), "`age` must be greater than 18" )')
-//     const res91 = generateAssertion('exclusiveMinimum', 'age', 18, false);
-//     assert(res91 === 'assert( age > 18, "`age` must be greater than 18" )')
+    const res9 = generateAssertion('exclusiveMinimum', 'age', 18, true);
+    assert(res9 === 'assert( age.forall(_ > 18), "`age` must be greater than 18" )')
+    const res91 = generateAssertion('exclusiveMinimum', 'age', 18, false);
+    assert(res91 === 'assert( age > 18, "`age` must be greater than 18" )')
 
-//   });
-// });
+  });
+});
 
-// describe('Validate string-like operations', () => {
-//   it('should validate number-like operations as expected', () => {
-//     const res10 = generateAssertion('maxLength', 'name', 200, true);
-//     assert(res10 === 'assert( name.forall(_.length <= 200), "`name` does not meet maximum length of 200" )')
-//     const res101 = generateAssertion('maxLength', 'name', 200, false);
-//     assert(res101 === 'assert( name.length <= 200, "`name` does not meet maximum length of 200" )')
+describe('Validate string-like operations', () => {
+  it('should validate number-like operations as expected', () => {
+    const res10 = generateAssertion('maxLength', 'name', 200, true);
+    assert(res10 === 'assert( name.forall(_.length <= 200), "`name` does not meet maximum length of 200" )')
+    const res101 = generateAssertion('maxLength', 'name', 200, false);
+    assert(res101 === 'assert( name.length <= 200, "`name` does not meet maximum length of 200" )')
 
-//     const res11 = generateAssertion('minLength', 'name', 10, true);
-//     assert(res11 === 'assert( name.forall(_.length >= 10), "`name` does not meet minimum length of 10" )')
-//     const res111 = generateAssertion('minLength', 'name', 10, false);
-//     assert(res111 === 'assert( name.length >= 10, "`name` does not meet minimum length of 10" )')
+    const res11 = generateAssertion('minLength', 'name', 10, true);
+    assert(res11 === 'assert( name.forall(_.length >= 10), "`name` does not meet minimum length of 10" )')
+    const res111 = generateAssertion('minLength', 'name', 10, false);
+    assert(res111 === 'assert( name.length >= 10, "`name` does not meet minimum length of 10" )')
 
-//     const res12 = generateAssertion('pattern', 'name', '/[a-zA-Z0-9]/', true);
-//     assert(res12 === 'assert( name.forall(_.matches("/[a-zA-Z0-9]/")), "`name` does not match the pattern" )')
-//     const res121 = generateAssertion('pattern', 'name', '/[a-zA-Z0-9]/', false);
-//     assert(res121 === 'assert( name.matches("/[a-zA-Z0-9]/"), "`name` does not match the pattern" )')
-//   });
-// });
+    const res12 = generateAssertion('pattern', 'name', '/[a-zA-Z0-9]/', true);
+    assert(res12 === 'assert( name.forall(_.matches("/[a-zA-Z0-9]/")), "`name` does not match the pattern" )')
+    const res121 = generateAssertion('pattern', 'name', '/[a-zA-Z0-9]/', false);
+    assert(res121 === 'assert( name.matches("/[a-zA-Z0-9]/"), "`name` does not match the pattern" )')
+  });
+});

--- a/tests/validations.test.ts
+++ b/tests/validations.test.ts
@@ -1,0 +1,73 @@
+// import { generateAssertion } from '../src/validations_v2';
+// import { assert } from 'chai';
+
+// describe('Validate array-like operations', () => {
+//   it('should validate array-like operations as expected', () => {
+//     const res1 = generateAssertion('minItems', 'tags', 0, true);
+//     assert(res1 === 'assert( tags.forall(_.length >= 0), "`tags` must have minimum 0 item(s)" )')
+//     const res11 = generateAssertion('minItems', 'tags', 2, false);
+//     assert(res11 === 'assert( tags.length >= 2, "`tags` must have minimum 2 item(s)" )')
+//     const res2 = generateAssertion('minItems', 'tags', 1, true);
+//     assert(res2 === 'assert( tags.forall(_.nonEmpty), "`tags` must have minimum 1 item(s)" )')
+//     const res21 = generateAssertion('minItems', 'tags', 4, false);
+//     assert(res21 === 'assert( tags.length >= 4, "`tags` must have minimum 4 item(s)" )')
+
+//     const res3 = generateAssertion('maxItems', 'tags', 0, true);
+//     assert(res3 === 'assert( tags.forall(_.isEmpty), "`tags` must have maximum 0 item(s)" )')
+//     const res31 = generateAssertion('maxItems', 'tags', 2, false);
+//     assert(res31 === 'assert( tags.length <= 2, "`tags` must have maximum 2 item(s)" )')
+
+//     const res4 = generateAssertion('uniqueItems', 'tags', null, true);
+//     assert(res4 === 'assert( tags.forall(_.length > _.distinct.length), "`tags` contains duplicate items" )')
+//     const res41 = generateAssertion('uniqueItems', 'tags', null, false);
+//     assert(res41 === 'assert( tags.length > tags.distinct.length, "`tags` contains duplicate items" )')
+
+//     const res5 = generateAssertion('multipleOf', 'age', 3, true);
+//     assert(res5 === 'assert( age.forall(_ % 3 === 0), "`age` must be multiple of (divisible by) 3" )')
+//     const res51 = generateAssertion('multipleOf', 'age', 5, false);
+//     assert(res51 === 'assert( age % 5 === 0, "`age` must be multiple of (divisible by) 5" )')
+//   });
+// });
+
+// describe('Validate number like operations', () => {
+//   it('should validate number-like operations as expected', () => {
+//     const res6 = generateAssertion('maximum', 'age', 18, true);
+//     assert(res6 === 'assert( age.forall(_ <= 18), "`age` must be less than or equal to 18" )')
+//     const res61 = generateAssertion('maximum', 'age', 18, false);
+//     assert(res61 === 'assert( age <= 18, "`age` must be less than or equal to 18" )')
+//     const res7 = generateAssertion('minimum', 'age', 18, true);
+//     assert(res7 === 'assert( age.forall(_ >= 18), "`age` must be greater than or equal to 18" )')
+//     const res71 = generateAssertion('minimum', 'age', 18, false);
+//     assert(res71 === 'assert( age >= 18, "`age` must be greater than or equal to 18" )')
+
+//     const res8 = generateAssertion('exclusiveMaximum', 'age', 18, true);
+//     assert(res8 === 'assert( age.forall(_ < 18), "`age` must be less than 18" )')
+//     const res81 = generateAssertion('exclusiveMaximum', 'age', 18, false);
+//     assert(res81 === 'assert( age < 18, "`age` must be less than 18" )')
+
+//     const res9 = generateAssertion('exclusiveMinimum', 'age', 18, true);
+//     assert(res9 === 'assert( age.forall(_ > 18), "`age` must be greater than 18" )')
+//     const res91 = generateAssertion('exclusiveMinimum', 'age', 18, false);
+//     assert(res91 === 'assert( age > 18, "`age` must be greater than 18" )')
+
+//   });
+// });
+
+// describe('Validate string-like operations', () => {
+//   it('should validate number-like operations as expected', () => {
+//     const res10 = generateAssertion('maxLength', 'name', 200, true);
+//     assert(res10 === 'assert( name.forall(_.length <= 200), "`name` does not meet maximum length of 200" )')
+//     const res101 = generateAssertion('maxLength', 'name', 200, false);
+//     assert(res101 === 'assert( name.length <= 200, "`name` does not meet maximum length of 200" )')
+
+//     const res11 = generateAssertion('minLength', 'name', 10, true);
+//     assert(res11 === 'assert( name.forall(_.length >= 10), "`name` does not meet minimum length of 10" )')
+//     const res111 = generateAssertion('minLength', 'name', 10, false);
+//     assert(res111 === 'assert( name.length >= 10, "`name` does not meet minimum length of 10" )')
+
+//     const res12 = generateAssertion('pattern', 'name', '/[a-zA-Z0-9]/', true);
+//     assert(res12 === 'assert( name.forall(_.matches("/[a-zA-Z0-9]/")), "`name` does not match the pattern" )')
+//     const res121 = generateAssertion('pattern', 'name', '/[a-zA-Z0-9]/', false);
+//     assert(res121 === 'assert( name.matches("/[a-zA-Z0-9]/"), "`name` does not match the pattern" )')
+//   });
+// });


### PR DESCRIPTION
Addresses the issue https://github.com/cchandurkar/json-schema-to-case-class/issues/32. Generate more fail-safe assertations. 

For example:
```scala
assert( age.forall(_ <= 18), "`age` must be less than or equal to 18" )
````
instead of
```scala
assert( age.get <= 18, "`age` must be less than or equal to 18" )
```